### PR TITLE
Added function getLastModifiedValidSave() in SaveManager class

### DIFF
--- a/src/main/java/com/dazednconfused/catalauncher/backup/SaveManager.java
+++ b/src/main/java/com/dazednconfused/catalauncher/backup/SaveManager.java
@@ -113,10 +113,32 @@ public class SaveManager {
                 .filter(file -> !file.getName().equals(".DS_Store"))
                 .collect(Collectors.toList());
     }
+    /**
+     * If save files exist in {@link com.dazednconfused.catalauncher.helper.Constants#CUSTOM_SAVE_PATH}, returns the last modified valid save file. Save file is valid if has a .sav file in it.
+     * */
 
+    public static Optional<File> getLastModifiedValidSave() {
+        File savesFolder = new File(CUSTOM_SAVE_PATH);
+        if (!saveFilesExist()) {
+            return Optional.empty();
+        }
+        File[] saveDirs = savesFolder.listFiles(file -> file.isDirectory() && !file.getName().equals(".DS_Store"));
+        Arrays.sort(saveDirs, Comparator.comparingLong(File::lastModified).reversed());
+
+        for (File directory : saveDirs) {
+            File[] savFiles = directory.listFiles((dir, name) -> name.endsWith(".sav"));
+            if (savFiles != null && savFiles.length > 0) {
+                return Optional.of(directory);
+            }
+        }
+
+        return Optional.empty(); // No directory with .sav file found
+
+    }
     /**
      * Determines whether save files exist in {@link com.dazednconfused.catalauncher.helper.Constants#CUSTOM_SAVE_PATH}.
      * */
+
     public static boolean saveFilesExist() {
         File savesFolder = new File(CUSTOM_SAVE_PATH);
         return savesFolder.exists() && Arrays.stream(Objects.requireNonNull(savesFolder.listFiles())).anyMatch(file -> !file.getName().equals(".DS_Store"));
@@ -129,16 +151,11 @@ public class SaveManager {
      * */
     public static Optional<File> getLatestSave() {
 
-        if (!saveFilesExist()) {
+        if (!saveFilesExist() || (getLastModifiedValidSave().orElse(null) == null)) {
             LOGGER.debug("No saves found. No latest save can be retrieved.");
             return Optional.empty();
         }
-
-        File savesFolder = new File(CUSTOM_SAVE_PATH);
-
-        return Arrays.stream(Objects.requireNonNull(savesFolder.listFiles()))
-                .filter(file -> !file.getName().equals(".DS_Store"))
-                .max(Comparator.comparingLong(File::lastModified));
+        return getLastModifiedValidSave();
     }
 
     /**

--- a/src/main/java/com/dazednconfused/catalauncher/gui/MainWindow.java
+++ b/src/main/java/com/dazednconfused/catalauncher/gui/MainWindow.java
@@ -243,7 +243,7 @@ public class MainWindow {
             }
 
             // DETERMINE IF RUN LATEST WORLD BUTTON SHOULD BE ENABLED ---
-            if (pathPointsToValidGameExecutable && saveFilesExist) {
+            if (pathPointsToValidGameExecutable && saveFilesExist && !(SaveManager.getLatestSave().orElse(null) == null)) {
                 this.runLatestWorldButton.setEnabled(true);
             } else {
                 this.runLatestWorldButton.setEnabled(false);


### PR DESCRIPTION
This should solve #24 

getLastModifiedValidSave() is used in SaveManager.java and MainWindow.java. It gets the last modified save directory with a .sav file in it, and is basically a helper function for SaveManager.getLastSaved()

In MainWindow.java, the run last world button is not enabled until both saveFilesExist, and getLastSaved() returns a valid saved world.