### PR TITLE
Creates monitorCddaProcess to check when game exit

### DIFF
--- a/src/main/java/com/dazednconfused/catalauncher/gui/MainWindow.java
+++ b/src/main/java/com/dazednconfused/catalauncher/gui/MainWindow.java
@@ -192,11 +192,10 @@ public class MainWindow {
 
             String[] launcherArgs = ArrayUtils.addAll(CUSTOM_SAVE_DIR_ARGS, CUSTOM_USER_DIR_ARGS);
 
-            CDDALauncherManager.executeCddaApplication(
+            Process cddaProcess = CDDALauncherManager.executeCddaApplication(
                     ConfigurationManager.getInstance().getCddaPath(), launcherArgs
             );
-
-            this.refreshGuiElements();
+            CDDALauncherManager.monitorCddaProcess(cddaProcess, this::refreshGuiElements);
         });
 
         // RUN LATEST WORLD BUTTON LISTENER ---
@@ -208,11 +207,10 @@ public class MainWindow {
                     ArrayUtils.addAll(CUSTOM_SAVE_DIR_ARGS, CUSTOM_USER_DIR_ARGS), lastWorldArgs
             );
 
-            CDDALauncherManager.executeCddaApplication(
+            Process cddaProcess = CDDALauncherManager.executeCddaApplication(
                     ConfigurationManager.getInstance().getCddaPath(), launcherArgs
             );
-
-            this.refreshGuiElements();
+            CDDALauncherManager.monitorCddaProcess(cddaProcess, this::refreshGuiElements);
         });
 
         // OPEN FINDER BUTTON LISTENER ---

--- a/src/main/java/com/dazednconfused/catalauncher/launcher/CDDALauncherManager.java
+++ b/src/main/java/com/dazednconfused/catalauncher/launcher/CDDALauncherManager.java
@@ -35,6 +35,23 @@ public class CDDALauncherManager {
         LOGGER.info("Executing command [{}]", (Object) cmdarray);
 
         return Try.of(() -> Runtime.getRuntime().exec(cmdarray)).onFailure(t -> LOGGER.error("There was an error executing [{}]", cmdarray, t)).getOrNull();
+
+    }
+
+    /**
+     * Used to refresh GUI after game exits. Creates a new thread to monitor the CDDA application after it's been run, and waits for it to exit.
+     * When it exits, it executes a Runnable object (in this case, it is passed refreshGuiElements in MainWindow.java)
+     * */
+    public static void monitorCddaProcess(Process process, Runnable onExit) {
+        new Thread(() -> {
+            try {
+                int exitCode = process.waitFor();
+                LOGGER.info("CDDA process exited with code {}", exitCode);
+                onExit.run();
+            } catch (InterruptedException e) {
+                LOGGER.error("Interrupted while waiting for CDDA process to exit", e);
+            }
+        }).start();
     }
 
     /**


### PR DESCRIPTION
This is meant to solve issue #4 

monitorCddaProcess creates a new thread to wait for the game to exit. When it does, it refreshes the GUI.